### PR TITLE
upgrade to monaco 1.5.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ RUN GOOS=linux go build -ldflags '-linkmode=external' $BUILDFLAGS -v -o monaco-s
 # https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds
 FROM alpine:3.11
 ENV ENV=production
-ARG monaco_version=v1.1.0
+ARG monaco_version=v1.5.2
 # Install extra packages
 # See https://github.com/gliderlabs/docker-alpine/issues/136#issuecomment-272703023
 


### PR DESCRIPTION
This PR upgrades the monaco dependency to be able to define Dynatrace SLOs via monaco
Signed-off-by: Florian Bacher <florian.bacher@dynatrace.com>